### PR TITLE
8 -DELETE /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -81,12 +81,12 @@ describe("GET /api/articles/:article_id", () => {
       });
   });
 
-  test("400: Responds with '<article_id> is not a valid id' when article_id is not a valid number", () => {
+  test("400: Responds with 'Not a valid id' when article_id is not a valid number", () => {
     return request(app)
       .get("/api/articles/notanumber")
       .expect(400)
       .then(({ body: { message } }) => {
-        expect(message).toBe("notanumber is not a valid id");
+        expect(message).toBe("Not a valid id");
       });
   });
 });
@@ -175,12 +175,12 @@ describe("GET /api/articles/:article_id/comments", () => {
     );
   });
 
-  test("400: 400: Responds with '<article_id> is not a valid id' when article_id is not a valid number", () => {
+  test("400: 400: Responds with 'Not a valid id' when article_id is not a valid number", () => {
     return request(app)
       .get("/api/articles/banana/comments")
       .expect(400)
       .then(({ body: { message } }) => {
-        expect(message).toBe("banana is not a valid id");
+        expect(message).toBe("Not a valid id");
       });
   });
 
@@ -240,7 +240,7 @@ describe("POST /api/articles/:article_id/comments", () => {
       });
   });
 
-  test("400: Responds with '<article_id> is not a valid id' when article_id is not a valid number", () => {
+  test("400: Responds with 'Not a valid id' when article_id is not a valid number", () => {
     return request(app)
       .post("/api/articles/banana/comments")
       .send({
@@ -249,7 +249,7 @@ describe("POST /api/articles/:article_id/comments", () => {
       })
       .expect(400)
       .then(({ body: { message } }) => {
-        expect(message).toBe("banana is not a valid id");
+        expect(message).toBe("Not a valid id");
       });
   });
 
@@ -322,13 +322,13 @@ describe("PATCH /api/articles/:article_id", () => {
       });
   });
 
-  test("400: Responds with '<article_id> is not a valid id' when article_id is not a valid number", () => {
+  test("400: Responds with 'Not a valid id' when article_id is not a valid number", () => {
     return request(app)
       .patch("/api/articles/banana")
       .send({ inc_votes: 50 })
       .expect(400)
       .then(({ body: { message } }) => {
-        expect(message).toBe("banana is not a valid id");
+        expect(message).toBe("Not a valid id");
       });
   });
 
@@ -349,6 +349,38 @@ describe("PATCH /api/articles/:article_id", () => {
       .expect(400)
       .then(({ body: { message } }) => {
         expect(message).toBe("inc_votes should be a number");
+      });
+  });
+});
+
+describe("DELETE /api/comments/:comment_id", () => {
+  test("204: On successful deletion of comment", () => {
+    return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+      .then(() => {
+        return db.query("SELECT * FROM comments WHERE comment_id = 1");
+      })
+      .then(({ rows }) => {
+        expect(rows.length).toBe(0);
+      });
+  });
+
+  test("404: If comment with given id does not exist", () => {
+    return request(app)
+      .delete("/api/comments/20")
+      .expect(404)
+      .then(({ body: { message } }) => {
+        expect(message).toBe("Comment with id 20 does not exist");
+      });
+  });
+
+  test("400: If given id is invalid", () => {
+    return request(app)
+      .delete("/api/comments/banana")
+      .expect(400)
+      .then(({ body: { message } }) => {
+        expect(message).toBe("Not a valid id");
       });
   });
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,7 +1,7 @@
 const { checkArticleExists } = require("../app/utils/checkArticleExists.js");
 const {
-  checkIfValidArticleId,
-} = require("../app/utils/checkIfValidArticleId.js");
+  checkIfValidId: checkIfValidArticleId,
+} = require("../app/utils/checkIfValidId.js");
 const { getKeyString } = require("../app/utils/format.js");
 const db = require("../db/connection.js");
 const {
@@ -134,7 +134,7 @@ describe("checkIfValidArticleId", () => {
   test("400: Should reject if article Id is not valid", () => {
     expect(checkIfValidArticleId("banana")).rejects.toEqual({
       status: 400,
-      message: "banana is not a valid id",
+      message: "Not a valid id",
     });
   });
 });

--- a/app/Controllers/comments.controller.js
+++ b/app/Controllers/comments.controller.js
@@ -1,0 +1,13 @@
+const { deleteCommentById } = require("../Models/comments.model");
+
+exports.deleteComment = async (request, response, next) => {
+  try {
+    const {
+      params: { comment_id },
+    } = request;
+    await deleteCommentById(comment_id);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/app/Models/articles.model.js
+++ b/app/Models/articles.model.js
@@ -1,6 +1,6 @@
 const db = require("../../db/connection.js");
 const { checkArticleExists } = require("../utils/checkArticleExists.js");
-const { checkIfValidArticleId } = require("../utils/checkIfValidArticleId.js");
+const { checkIfValidId } = require("../utils/checkIfValidId.js");
 const { getKeyString } = require("../utils/format.js");
 
 exports.selectArticles = async () => {
@@ -62,7 +62,6 @@ removeArticlesBody = (articles) => {
 };
 
 exports.selectArticleById = async (article_id) => {
-  await checkIfValidArticleId(article_id);
   await checkArticleExists(article_id);
   const articleSql = `
   SELECT * FROM articles
@@ -77,7 +76,6 @@ exports.selectArticleById = async (article_id) => {
 };
 
 exports.selectCommentsByArticleId = async (article_id) => {
-  await checkIfValidArticleId(article_id);
   await checkArticleExists(article_id);
   const commentSql = `
   SELECT * FROM comments
@@ -91,7 +89,7 @@ exports.selectCommentsByArticleId = async (article_id) => {
 };
 
 exports.insertComment = async (article_id, comment) => {
-  await checkIfValidArticleId(article_id);
+  await checkIfValidId(article_id);
   await checkArticleExists(article_id);
   const insertCommentSql = `
     INSERT INTO comments(author, body, article_id,  votes)
@@ -123,7 +121,6 @@ exports.insertComment = async (article_id, comment) => {
 };
 
 exports.updateArticle = async (article_id, inc_votes) => {
-  await checkIfValidArticleId(article_id);
   await checkArticleExists(article_id);
 
   if (inc_votes === undefined) {

--- a/app/Models/comments.model.js
+++ b/app/Models/comments.model.js
@@ -1,0 +1,14 @@
+const db = require("../../db/connection.js");
+const { checkCommentExists } = require("../utils/checkCommentExitsts");
+const { checkIfValidId } = require("../utils/checkIfValidId");
+
+exports.deleteCommentById = async (comment_id) => {
+  await checkCommentExists(comment_id);
+  await checkIfValidId(comment_id);
+  const deleteSql = `
+    DELETE FROM comments
+    WHERE comment_id = $1
+    `;
+
+  return db.query(deleteSql, [comment_id]);
+};

--- a/app/app.js
+++ b/app/app.js
@@ -8,6 +8,7 @@ const {
   postComment,
   patchArticle,
 } = require("./Controllers/articles.controller");
+const { deleteComment } = require("./Controllers/comments.controller");
 const app = express();
 app.use(express.json());
 
@@ -18,6 +19,7 @@ app.get("/api/articles/:article_id", getArticleById);
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 app.post("/api/articles/:article_id/comments", postComment);
 app.patch("/api/articles/:article_id", patchArticle);
+app.delete("/api/comments/:comment_id", deleteComment);
 
 app.all("*", (request, response) => {
   response.status(404).send({ message: "Endpoint not found" });
@@ -25,7 +27,7 @@ app.all("*", (request, response) => {
 
 app.use((error, request, response, next) => {
   if (error.code === "22P02") {
-    response.status(400).send({ message: "Bad Request" });
+    response.status(400).send({ message: "Not a valid id" });
   } else {
     next(error);
   }

--- a/app/utils/checkCommentExitsts.js
+++ b/app/utils/checkCommentExitsts.js
@@ -1,0 +1,20 @@
+const db = require("../../db/connection.js");
+exports.checkCommentExists = async (comment_id) => {
+  const selectCommentSql = `
+    SELECT * FROM comments
+    WHERE comment_id = $1
+    `;
+
+  const { rows: comments, rowCount } = await db.query(selectCommentSql, [
+    comment_id,
+  ]);
+
+  if (rowCount === 0) {
+    return Promise.reject({
+      status: 404,
+      message: `Comment with id ${comment_id} does not exist`,
+    });
+  } else {
+    return;
+  }
+};

--- a/app/utils/checkIfValidId.js
+++ b/app/utils/checkIfValidId.js
@@ -1,9 +1,9 @@
-exports.checkIfValidArticleId = (article_id) => {
+exports.checkIfValidId = (id) => {
   //if article_id isn't numeric
-  if (isNaN(article_id)) {
+  if (isNaN(id)) {
     return Promise.reject({
       status: 400,
-      message: `${article_id} is not a valid id`,
+      message: `Not a valid id`,
     });
   } else {
     return Promise.resolve(undefined);

--- a/endpoints.json
+++ b/endpoints.json
@@ -29,7 +29,7 @@
   },
 
   "GET /api/articles/:article_id": {
-    "description": "gives a spefic article object based on the :article_id param",
+    "description": "gives a specific article object based on :article_id",
     "queries": [],
     "exampleResponse": {
       "article": [
@@ -44,6 +44,61 @@
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
         }
       ]
+    }
+  },
+
+  "GET /api/articles/:article_id/comments": {
+    "description": "get all comments for a specific article object",
+    "queries": [],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 1,
+          "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+          "article_id": 9,
+          "author": "butter_bridge",
+          "votes": 16,
+          "created_at": "2020-04-06T12:17:00.000Z"
+        },
+        {
+          "comment_id": 17,
+          "body": "The owls are not what they seem.",
+          "article_id": 9,
+          "author": "icellusedkars",
+          "votes": 20,
+          "created_at": "2020-03-14T17:02:00.000Z"
+        }
+      ]
+    }
+  },
+  "POST /api/articles/:article_id/comments": {
+    "description": "Add a comment to a specific article",
+    "queries": [],
+    "exampleResponse": {
+      "comment": {
+        "comment_id": 19,
+        "body": "wow what a cool article",
+        "article_id": 1,
+        "author": "lurker",
+        "votes": 0,
+        "created_at": "2025-01-28T15:29:48.990Z"
+      }
+    }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "Increment an articles votes parameter by sent inc_votes key on request",
+    "queries": [],
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "body": "I find this existence challenging",
+        "created_at": "2020-07-09T20:11:00.000Z",
+        "votes": 150,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }
     }
   }
 }


### PR DESCRIPTION
Add 8 -DELETE /api/comments/:comment_id
204: Deletes a comment via its id returns no content
404: When comment dosen't exist
400: When comment_id is an invalid id

Refactored some end points to utilise more sql errors